### PR TITLE
[WIP] Improve parse error

### DIFF
--- a/SHerLOC/Parsing/Operations.lean
+++ b/SHerLOC/Parsing/Operations.lean
@@ -159,7 +159,7 @@ def parseOpCode : PState OpCode := do
   if let some op := opCode then
     parseItem "\""
     return op
-  else throw <| (← error "op code")
+  else throw (← errorSimple (String.join ["Unknown op code: '", opCodeString, "'"]))
 
 mutual
 
@@ -167,7 +167,7 @@ mutual
     parseItem "{"
     let mut funcInputs : List FuncInput := []
     if ← is "^" then
-      discard <| parseUnusedId
+      discard parseUnusedId
       funcInputs ← parseInputFuncInputs
       parseItem ":"
     let body ← parseInputFuncBody

--- a/SHerLOC/Parsing/Parser.lean
+++ b/SHerLOC/Parsing/Parser.lean
@@ -46,7 +46,7 @@ structure ParsingState where
 
 abbrev PState (T : Type) := StateT ParsingState (Except (String × List Trace × List Derivation)) T
 
-def error (msg : String) : PState (String × (List Trace) × (List Derivation) ):= do
+def error (msg : String) : PState (String × (List Trace) × (List Derivation)) := do
   let st ← get
   let mut token := ""
   let mut started := false
@@ -60,6 +60,11 @@ def error (msg : String) : PState (String × (List Trace) × (List Derivation) )
     else if c = ' ' || c = '\t' || c = '\n' then break
     else token := token.push c
   let errorMsg := s!"Parsing error line {st.lineNumber}, column {st.columnNumber} : expected {msg} but found {token}"
+  return (errorMsg, st.trace, st.derivations)
+
+def errorSimple (msg : String) : PState (String × (List Trace) × (List Derivation)) := do
+  let st ← get
+  let errorMsg := s!"Parsing error line {st.lineNumber}, column {st.columnNumber} : {msg}"
   return (errorMsg, st.trace, st.derivations)
 
 def report (msg : String) : PState Unit := do


### PR DESCRIPTION
Attempts to address https://github.com/leanprover/SHerLOC/issues/19 Currently reports the column of the closing quote of the operator. Not amazing, but also not clear how to get the starting column. Perhaps it's embedded in the hd of `state.trace` but I haven't grokked the parser enough yet to know.

Definitely open to feedback on this one!

Example:

```
"builtin.module"() ({
  "func.func"() <{function_type = (tensor<28x28xf32>, tensor<784x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>, sym_name = "main"}> ({
  ^bb0(%arg0: tensor<28x28xf32>, %arg1: tensor<784x10xf32>, %arg2: tensor<1x10xf32>):
    %0 = "stablehlo.reshape"(%arg0) : (tensor<28x28xf32>) -> tensor<1x784xf32>
    %1 = "stablehlo.dot"(%0, %arg1) : (tensor<1x784xf32>, tensor<784x10xf32>) -> tensor<1x10xf32>
    %2 = "stablehlo.add"(%1, %arg2) : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
    %3 = "stablehlo.constant"() <{value = dense<0.000000e+00> : tensor<1x10xf32>}> : () -> tensor<1x10xf32>
    %4 = "stablehlo.foo"(%2, %3) : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
    "func.return"(%4) : (tensor<1x10xf32>) -> ()
  }) : () -> ()
}) : () -> ()
```

```
Parsing error line 8, column 23 : Unknown op code: 'foo'
```