### PR TITLE
chore: bump lean version to 4.20 to match KLR

### DIFF
--- a/SHerLOC/Analysis/Ops.lean
+++ b/SHerLOC/Analysis/Ops.lean
@@ -3,7 +3,7 @@ import SHerLOC.AST1
 namespace StableHLO.Analysis
 
 def uniqueOps (p : List Parsing.Module) : List String :=
-  let ops := p.bind (fun {modFuncs, .. } => modFuncs.bind (fun {funcBody := .mk _ body, .. } => body.map (fun i =>
+  let ops := p.flatMap (fun {modFuncs, .. } => modFuncs.flatMap (fun {funcBody := .mk _ body, .. } => body.map (fun i =>
   match i with
   | .stablehlo o _ _ _ _ _ => s!"{repr o}"
   | .tanh _ _ => "tanh"

--- a/SHerLOC/Parsing/Operations.lean
+++ b/SHerLOC/Parsing/Operations.lean
@@ -324,7 +324,7 @@ partial def parseStableHLO (opOutputs : List ValueId) : PState Operation := do
     else {
       parseItem ":"
       let functionType ← parseFunctionType
-      return Operation.tanh (opInputValues.get! 0) functionType
+      return Operation.tanh (opInputValues[0]!) functionType
     }
   }
   | OpCode.transpose => parseOperationBasic OpCode.transpose opOutputs

--- a/SHerLOC/Parsing/Parser.lean
+++ b/SHerLOC/Parsing/Parser.lean
@@ -159,7 +159,7 @@ def isChar (c : Char) : PState Bool := do
 
 def parseItems (keywords : List String) : PState Unit := do
   for i in [:keywords.length] do
-    parseItem <| keywords.get! i
+    parseItem <| keywords[i]!
 
 def parseFId : PState String := do
   skip

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.10.0
+leanprover/lean4:v4.20.0


### PR DESCRIPTION
Bumping the Lean version to 4.20 to match the version used by KLR. Also fixed some deprecation warnings caused by updating the version.